### PR TITLE
Change "Viestin alkuperäinen lähettäjä" with actual name of the poster

### DIFF
--- a/reasons.json
+++ b/reasons.json
@@ -20,9 +20,9 @@
             "description": "by Treycos on Stackoverflow"
         },
         {
-            "url": "https://support.google.com/mail/forum/AAAAK7un8RU2Kf-LgmiV8Q/?hl=fi",
+            "url": "https://support.google.com/mail/forum/AAAAK7un8RU2Kf-LgmiV8Q/",
             "label": "gmail does not work correctly on IE11",
-            "description": "by Viestin alkuperäinen lähettäjä on google support"
+            "description": "by sapmaz on google support"
         }
         
     ]


### PR DESCRIPTION
This is quite funny if you speak finnish so I was tempted to leave it in… "Viestin alkuperäinen lähettäjä" just means "original sender", it’s not the name of a person. 

Changing the page’s language on https://support.google.com/mail/forum/AAAAK7un8RU2Kf-LgmiV8Q/, you can see Google displays this text as "Original poster" in English.

This PR credits the actual person based on their username, and changes the link to be to the language-agnostic version of the page.