### PR TITLE
Add Reasons to drop support for Internet Explorer 11 #29

### DIFF
--- a/src/data/reasons.js
+++ b/src/data/reasons.js
@@ -33,6 +33,11 @@ export default {
             "url": "https://css-tricks.com/a-business-case-for-dropping-internet-explorer/",
             "label": "A Business Case for Dropping Internet Explorer",
             "description": "by @CSSTricks"
+        },
+        {
+            "url": "https://www.knowage-suite.com/qa/4943/problems-with-ie11",
+            "label": "generating and displaying cockpits in Internet Explorer 11",
+            "description": "by vvk"
         }
     ]
 }

--- a/src/data/websites.js
+++ b/src/data/websites.js
@@ -75,6 +75,11 @@ export default {
         {
             "url": "https://help.twitter.com/fr/using-twitter/twitter-supported-browsers",
             "label": "twitter"
+        },
+        
+        {
+            "url": "https://answers.microsoft.com/en-us/ie/forum/all/websites-telling-me-they-will-no-longer-support/5caf94d0-facd-43db-93d0-4745feec10b7",
+            "label": "Facebook"
         }
     ]
 }

--- a/src/data/websites.js
+++ b/src/data/websites.js
@@ -79,7 +79,7 @@ export default {
         
         {
             "url": "https://answers.microsoft.com/en-us/ie/forum/all/websites-telling-me-they-will-no-longer-support/5caf94d0-facd-43db-93d0-4745feec10b7",
-            "label": "Facebook"
+            "label": "facebook"
         }
     ]
 }


### PR DESCRIPTION
Added reason for dropping supporting ie11 : generating and displaying cockpits in Internet Explorer 11 is not supported