### PR TITLE
fix: jumpy counter text

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -173,6 +173,7 @@ section.countdown .timer .group .text {
 section.countdown .timer .group .value {
     font-size: 4rem;
     font-weight: 700;
+    font-variant-numberic: tabular-nums;
 }
 
 section.disclaimer {


### PR DESCRIPTION
I noticed the countdown on your site is using a non-monospace font and would like to propose using `font-variant-numeric` to fix it looking jumpy as numbers have different widths.