### PR TITLE
Feature/counter layout

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -127,9 +127,6 @@ section.landing .chevrons-down:focus {
 }
 
 section.countdown {
-    display: grid;
-    grid-template-columns: minmax(300px, 1050px);
-    justify-content: center;
     min-height: 0;
     width: 100%;
 }
@@ -255,12 +252,10 @@ footer {
         font-size: 1.2rem;
     }
     section.countdown {
-        display: grid;
-        grid-template-columns: auto;
-        grid-template-rows: 1fr 1fr;
+        max-width: 30rem;
     }
     section.countdown > div {
-        padding: 1rem 0.5rem;
+        padding: 1rem 0;
     }
     section.countdown .mainstream {
         border-right: 0;

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -173,7 +173,7 @@ section.countdown .timer .group .text {
 section.countdown .timer .group .value {
     font-size: 4rem;
     font-weight: 700;
-    font-variant-numberic: tabular-nums;
+    font-variant-numeric: tabular-nums;
 }
 
 section.disclaimer {


### PR DESCRIPTION
The very first time I visited the website I was surprised when I saw "10 years" left (!!!!), until I realized there was just a need of some space. This PR makes the counter look good in all screen sizes, and also fixes the "jumpy counter text" ✨

![image](https://user-images.githubusercontent.com/9013965/120505447-46e02380-c3c5-11eb-96f8-93b3c05f1245.png)
