### PR TITLE
Add Wordpress to websites list

### DIFF
--- a/src/data/websites.js
+++ b/src/data/websites.js
@@ -111,6 +111,10 @@ export default {
         {
             "url": "https://github.com/angular/angular/issues/41840",
             "label": "Angular 13"
+        },
+        {
+            "url": "https://wordpress.org/news/2021/05/dropping-support-for-internet-explorer-11/",
+            "label": "Wordpress"
         }
     ]
 }


### PR DESCRIPTION
Added a link to https://wordpress.org/news/2021/05/dropping-support-for-internet-explorer-11/