### PR TITLE
WordPress not Wordpress, capital_p_dangit()

### DIFF
--- a/src/data/websites.js
+++ b/src/data/websites.js
@@ -105,7 +105,7 @@ export default {
         },
         {
             "url": "https://wordpress.org/news/2021/05/dropping-support-for-internet-explorer-11/",
-            "label": "Wordpress"
+            "label": "WordPress"
         },
         {
             "url": "https://help.yahoo.com/kb/SLN4556.html?guccounter=1",


### PR DESCRIPTION
Fixes the misspelling of WordPress to its official spelling. If Youtube can have YouTube then so can we!