### PR TITLE
Update time of death

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import countdown from "./js/countdown";
 import populateReasonsAndWebsites from "./js/reasonsAndWebsites";
 
 countdown(
-  "06/15/2022 05:00:00 PM",
+  "06/15/2022 12:52:56 PM",
   "extendedTimer",
   "Support ends in",
   "Internet Explorer is finally dead and has been dead for"


### PR DESCRIPTION
Microsoft's blog says it's officially dead. 

https://blogs.windows.com/windowsexperience/2022/06/15/internet-explorer-11-has-retired-and-is-officially-out-of-support-what-you-need-to-know/ 

View source, line 64

`<meta property="article:published_time" content="2022-06-15T12:52:56+00:00" />`
