### PR TITLE
@rebeccahongsf | update date time to ISO 8601 format to account for different time zones

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import countdown from "./js/countdown";
 import populateReasonsAndWebsites from "./js/reasonsAndWebsites";
 
 countdown(
-  "06/15/2022 12:52:56 PM",
+  "2022-06-15T13:36:00.000Z",
   "extendedTimer",
   "Support ends in",
   "Internet Explorer is finally dead and has been dead for"

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import countdown from "./js/countdown";
 import populateReasonsAndWebsites from "./js/reasonsAndWebsites";
 
 countdown(
-  "2022-06-15T13:36:00.000Z",
+  "2022-06-15T12:52:56+00:00",
   "extendedTimer",
   "Support ends in",
   "Internet Explorer is finally dead and has been dead for"


### PR DESCRIPTION
- [x] I have reviewed the [Code of Conduct](https://github.com/gabLaroche/death-to-ie11/blob/develop/CODE_OF_CONDUCT.md) and [Contribution guidelines](https://github.com/gabLaroche/death-to-ie11/blob/develop/CONTRIBUTING.md)

Currently, the countdown timer displays a different countdown based on user timezone. 

Using an ISO 8601 date-time format `endDate` should resolve the time differences. I initially used the ISO 8601 date-time format from the [IE 11 Ended Support article published on June 15, 2022](https://docs.microsoft.com/en-us/lifecycle/announcements/internet-explorer-11-end-of-support) but saw the previously merged PR #86 and updated it to that ISO 8601 date-time instead. 

Let me know your thoughts! Thanks 😃 