### PR TITLE
Make countdown accurate based on current user agent time

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "build": "parcel build src/index.html"
   },
   "dependencies": {
-    "@js-temporal/polyfill": "0.4.3",
-    "parcel-bundler": "^1.12.4"
+    "parcel-bundler": "^1.12.4",
+    "temporal-polyfill": "^0.2.5"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "parcel build src/index.html"
   },
   "dependencies": {
+    "@js-temporal/polyfill": "0.4.3",
     "parcel-bundler": "^1.12.4"
   },
   "devDependencies": {

--- a/src/js/countdown.js
+++ b/src/js/countdown.js
@@ -1,11 +1,4 @@
-import { Temporal } from '@js-temporal/polyfill'
-
-function round(duration, relativeTo) {
-  const round_ = (duration) => duration.round({ relativeTo, largestUnit: 'year', smallestUnit: 'second' });
-
-  // https://github.com/tc39/proposal-temporal/issues/2508
-  return round_(round_(duration));
-}
+import { Temporal } from 'temporal-polyfill';
 
 export default function countdown(
   endDate,
@@ -20,8 +13,8 @@ export default function countdown(
 
   function getUiText() {
     const now = Temporal.Now.zonedDateTimeISO(timeZone);
+    const duration = now.until(endOfLife).round({ relativeTo: now, largestUnit: 'year', smallestUnit: 'second' });
 
-    const duration = round(now.until(endOfLife), now);
     const { sign } = duration;
     let { years, months, days, hours, minutes, seconds } = duration.abs();
 

--- a/src/js/countdown.js
+++ b/src/js/countdown.js
@@ -1,89 +1,41 @@
+import { Temporal } from '@js-temporal/polyfill'
+
+function round(duration, relativeTo) {
+  const round_ = (duration) => duration.round({ relativeTo, largestUnit: 'year', smallestUnit: 'second' });
+
+  // https://github.com/tc39/proposal-temporal/issues/2508
+  return round_(round_(duration));
+}
+
 export default function countdown(
   endDate,
   timerId,
   preDeathTagline,
   postDeathTagline
 ) {
-  let years, months, days, hours, minutes, seconds;
-  let yearsDesc, monthsDesc, daysDesc, hoursDesc, minutesDesc, secondsDesc;
-  let yearsNumber,
-    monthsNumber,
-    daysNumber,
-    hoursNumber,
-    minutesNumber,
-    secondsNumber;
+  const { timeZone } = Intl.DateTimeFormat().resolvedOptions();
+  const endOfLife = Temporal.Instant.from(endDate).toZonedDateTimeISO(timeZone);
 
-  endDate = new Date(endDate).getTime();
+  setInterval(render, 1000);
 
-  if (isNaN(endDate)) {
-    return;
+  function getUiText() {
+    const now = Temporal.Now.zonedDateTimeISO(timeZone);
+
+    const duration = round(now.until(endOfLife), now);
+    const { sign } = duration;
+    let { years, months, days, hours, minutes, seconds } = duration.abs();
+
+    [years, months, days] = [years, months, days].map(String);
+    [hours, minutes, seconds] = [hours, minutes, seconds].map(x => `${x}`.padStart(2, '0'));
+
+    const tagline = sign > 0 ? preDeathTagline : postDeathTagline;
+
+    return { tagline, years, months, days, hours, minutes, seconds };
   }
 
-  setInterval(calculate, 1000);
-
-  function calculate() {
-    let startDate = new Date();
-    startDate = startDate.getTime();
-
-    let timeRemaining = parseInt((endDate - startDate) / 1000);
-    let timeSince = parseInt((startDate - endDate) / 1000);
-    const timerContainer = document.getElementById(timerId);
-    const tagline = timerContainer.querySelector(".tagline");
-
-    const calculateProperTime = (time) => {
-      // Logic that calculates the time
-      years = parseInt(time / 3.154e7);
-      yearsDesc = years !== 1 ? "Years" : "Year";
-      yearsNumber = parseInt(years, 10);
-      time = time % 3.154e7;
-
-      months = parseInt(time / 2.628e6);
-      monthsDesc = months !== 1 ? "Months" : "Month";
-      monthsNumber = parseInt(months, 10);
-      time = time % 2.628e6;
-
-      days = parseInt(time / 86400);
-      daysDesc = days !== 1 ? "Days" : "Day";
-      daysNumber = parseInt(days, 10);
-      time = time % 86400;
-
-      hours = parseInt(time / 3600);
-      hoursDesc = hours !== 1 ? "Hours" : "Hour";
-      hoursNumber = ("0" + hours).slice(-2);
-      time = time % 3600;
-
-      minutes = parseInt(time / 60);
-      minutesDesc = minutes !== 1 ? "Minutes" : "Minute";
-      minutesNumber = ("0" + minutes).slice(-2);
-      time = time % 60;
-
-      seconds = parseInt(time);
-      secondsDesc = seconds !== 1 ? "Seconds" : "Second";
-      secondsNumber = ("0" + seconds).slice(-2);
-
-      // Populates the time description
-      timerContainer.querySelector(".yearsText").innerHTML = yearsDesc;
-      timerContainer.querySelector(".monthsText").innerHTML = monthsDesc;
-      timerContainer.querySelector(".daysText").innerHTML = daysDesc;
-      timerContainer.querySelector(".hoursText").innerHTML = hoursDesc;
-      timerContainer.querySelector(".minutesText").innerHTML = minutesDesc;
-      timerContainer.querySelector(".secondsText").innerHTML = secondsDesc;
-
-      // Populates the time numbers
-      timerContainer.querySelector(".years").innerHTML = yearsNumber;
-      timerContainer.querySelector(".months").innerHTML = monthsNumber;
-      timerContainer.querySelector(".days").innerHTML = daysNumber;
-      timerContainer.querySelector(".hours").innerHTML = hoursNumber;
-      timerContainer.querySelector(".minutes").innerHTML = minutesNumber;
-      timerContainer.querySelector(".seconds").innerHTML = secondsNumber;
-    };
-
-    if (timeRemaining >= 0) {
-      tagline.innerHTML = preDeathTagline;
-      calculateProperTime(timeRemaining);
-    } else {
-      tagline.innerHTML = postDeathTagline;
-      calculateProperTime(timeSince);
+  function render() {
+    for (const [key, val] of Object.entries(getUiText())) {
+      document.querySelector(`#${timerId} .${key}`).textContent = val;
     }
   }
 }


### PR DESCRIPTION
The current countdown (count-up?) is an approximation that doesn't take into account the number of days in each month, the user's timezone, leap years, DST, etc. This causes inaccuracy — it's currently showing `8 months, 7 days, 8 hours...` for me, whereas it should be `8 months, 5 days, 16 hours...` as of the time where I am.

This PR uses a polyfill for the upcoming [Temporal](https://tc39.es/proposal-temporal/docs/) API to accurately calculate the countdown in a context-aware way, based on the current user agent time.